### PR TITLE
Sn 26

### DIFF
--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.jsx
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.jsx
@@ -1,17 +1,49 @@
+import React from "react";
+import { useBackend } from "main/utils/useBackend";
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RecommendationRequestTable from "main/components/RecommendationRequest/RecommendationRequestTable";
+import { useCurrentUser, hasRole } from "main/utils/useCurrentUser";
+import { Button } from "react-bootstrap";
 
 export default function RecommendationRequestIndexPage() {
-  // Stryker disable all : placeholder for future implementation
+  const currentUser = useCurrentUser();
+
+  const {
+    data: recommendationRequests,
+    error: _error,
+    status: _status,
+  } = useBackend(
+    // Stryker disable next-line all : don't test internal caching of React Query
+    ["/api/recommendationrequest/all"],
+    { method: "GET", url: "/api/recommendationrequest/all" },
+    // Stryker disable next-line all : don't test default value of empty list
+    [],
+  );
+
+  const createButton = () => {
+    if (hasRole(currentUser, "ROLE_ADMIN")) {
+      return (
+        <Button
+          variant="primary"
+          href="/recommendationrequest/create"
+          style={{ float: "right" }}
+        >
+          Create Recommendation Request
+        </Button>
+      );
+    }
+  };
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Index page not yet implemented</h1>
-        <p>
-          <a href="/recommendationrequest/create">Create</a>
-        </p>
-        <p>
-          <a href="/recommendationrequest/edit/1">Edit</a>
-        </p>
+        {createButton()}
+        <h1>Recommendation Requests</h1>
+        <RecommendationRequestTable
+          recommendationRequests={recommendationRequests}
+          currentUser={currentUser}
+        />
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestIndexPage.stories.jsx
+++ b/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestIndexPage.stories.jsx
@@ -1,0 +1,75 @@
+import React from "react";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
+import { http, HttpResponse } from "msw";
+
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+
+export default {
+  title: "pages/RecommendationRequest/RecommendationRequestIndexPage",
+  component: RecommendationRequestIndexPage,
+};
+
+const Template = () => <RecommendationRequestIndexPage />;
+
+export const Empty = Template.bind({});
+Empty.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly, {
+        status: 200,
+      });
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither, {
+        status: 200,
+      });
+    }),
+    http.get("/api/recommendationrequest/all", () => {
+      return HttpResponse.json([], { status: 200 });
+    }),
+  ],
+};
+
+export const ThreeItemsOrdinaryUser = Template.bind({});
+
+ThreeItemsOrdinaryUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.userOnly);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/recommendationrequest/all", () => {
+      return HttpResponse.json(
+        recommendationRequestFixtures.threeRecommendationRequests,
+      );
+    }),
+  ],
+};
+
+export const ThreeItemsAdminUser = Template.bind({});
+
+ThreeItemsAdminUser.parameters = {
+  msw: [
+    http.get("/api/currentUser", () => {
+      return HttpResponse.json(apiCurrentUserFixtures.adminUser);
+    }),
+    http.get("/api/systemInfo", () => {
+      return HttpResponse.json(systemInfoFixtures.showingNeither);
+    }),
+    http.get("/api/recommendationrequest/all", () => {
+      return HttpResponse.json(
+        recommendationRequestFixtures.threeRecommendationRequests,
+      );
+    }),
+    http.delete("/api/recommendationrequest", () => {
+      return HttpResponse.json(
+        { message: "RecommendationRequest deleted successfully" },
+        { status: 200 },
+      );
+    }),
+  ],
+};

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.jsx
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.jsx
@@ -1,15 +1,28 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router";
+import mockConsole from "tests/testutils/mockConsole";
+import { recommendationRequestFixtures } from "fixtures/recommendationRequestFixtures";
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = vi.fn();
+vi.mock("react-toastify", async (importOriginal) => {
+  const originalModule = await importOriginal();
+  return {
+    ...originalModule,
+    toast: vi.fn((x) => mockToast(x)),
+  };
+});
+
 describe("RecommendationRequestIndexPage tests", () => {
   const axiosMock = new AxiosMockAdapter(axios);
+
+  const testId = "RecommendationRequestTable";
 
   const setupUserOnly = () => {
     axiosMock.reset();
@@ -22,9 +35,22 @@ describe("RecommendationRequestIndexPage tests", () => {
       .reply(200, systemInfoFixtures.showingNeither);
   };
 
+  const setupAdminUser = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
   const queryClient = new QueryClient();
-  test("Renders expected content", async () => {
-    setupUserOnly();
+
+  test("Renders with Create Button for admin user", async () => {
+    setupAdminUser();
+    axiosMock.onGet("/api/recommendationrequest/all").reply(200, []);
 
     render(
       <QueryClientProvider client={queryClient}>
@@ -34,12 +60,126 @@ describe("RecommendationRequestIndexPage tests", () => {
       </QueryClientProvider>,
     );
 
-    await screen.findByText("Index page not yet implemented");
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Create Recommendation Request/),
+      ).toBeInTheDocument();
+    });
+    const button = screen.getByText(/Create Recommendation Request/);
+    expect(button).toHaveAttribute("href", "/recommendationrequest/create");
+    expect(button).toHaveAttribute("style", "float: right;");
+  });
+
+  test("renders three recommendation requests correctly for regular user", async () => {
+    setupUserOnly();
+    axiosMock
+      .onGet("/api/recommendationrequest/all")
+      .reply(200, recommendationRequestFixtures.threeRecommendationRequests);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toHaveTextContent("1");
+    });
+    expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
+      "2",
+    );
+    expect(screen.getByTestId(`${testId}-cell-row-2-col-id`)).toHaveTextContent(
+      "3",
+    );
 
     expect(
-      screen.getByText("Index page not yet implemented"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("Create")).toBeInTheDocument();
-    expect(screen.getByText("Edit")).toBeInTheDocument();
+      screen.queryByText("Create Recommendation Request"),
+    ).not.toBeInTheDocument();
+
+    expect(screen.getByText("cgaucho@ucsb.edu")).toBeInTheDocument();
+
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Delete-button`),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId(`${testId}-cell-row-0-col-Edit-button`),
+    ).not.toBeInTheDocument();
+  });
+
+  test("renders empty table when backend unavailable, user only", async () => {
+    setupUserOnly();
+    axiosMock.onGet("/api/recommendationrequest/all").timeout();
+
+    const restoreConsole = mockConsole();
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1);
+    });
+
+    const errorMessage = console.error.mock.calls[0][0];
+    expect(errorMessage).toMatch(
+      "Error communicating with backend via GET on /api/recommendationrequest/all",
+    );
+    restoreConsole();
+  });
+
+  test("what happens when you click delete, admin", async () => {
+    setupAdminUser();
+
+    axiosMock
+      .onGet("/api/recommendationrequest/all")
+      .reply(200, recommendationRequestFixtures.threeRecommendationRequests);
+    axiosMock
+      .onDelete("/api/recommendationrequest")
+      .reply(200, "RecommendationRequest with id 1 was deleted");
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <RecommendationRequestIndexPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-id`),
+      ).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
+      "1",
+    );
+
+    const deleteButton = await screen.findByTestId(
+      `${testId}-cell-row-0-col-Delete-button`,
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => {
+      expect(mockToast).toBeCalledWith(
+        "RecommendationRequest with id 1 was deleted",
+      );
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.delete.length).toBe(1);
+    });
+    expect(axiosMock.history.delete[0].url).toBe("/api/recommendationrequest");
+    expect(axiosMock.history.delete[0].params).toEqual({ id: 1 });
   });
 });


### PR DESCRIPTION
## Description

Replaces the placeholder index page with a fully functional RecommendationRequestIndexPage.

### Changes
- `RecommendationRequestIndexPage.jsx` — fetches from `/api/recommendationrequest/all`, shows table with all records, Create button for admins
- `RecommendationRequestIndexPage.test.jsx` — 4 tests, 100% coverage + mutation score
- `RecommendationRequestIndexPage.stories.jsx` — Empty, ThreeItemsOrdinaryUser, ThreeItemsAdminUser stories

### How to test
1. Log in as regular user → navigate to `/recommendationrequest` → see table, no Create/Edit/Delete buttons
2. Log in as admin → navigate to `/recommendationrequest` → see Create button, Edit/Delete buttons per row
3. As admin, click Delete → record removed, toast shown

### Screenshot
<img width="1512" height="829" alt="image" src="https://github.com/user-attachments/assets/b81cc49c-03c7-4e7b-a8a1-e488872084a4" />



Closes #26